### PR TITLE
Make Torrentor handle magnet: links

### DIFF
--- a/source/torrentor/Application.cpp
+++ b/source/torrentor/Application.cpp
@@ -174,6 +174,16 @@ void TorrentorApp::RefsReceived(BMessage* message)
 
 }
 
+void TorrentorApp::ArgvReceived(int32 argc, char** argv)
+{
+	for (int32 i = 1; i < argc; i++) {
+		BString arg(argv[i]);
+		if (arg.FindFirst("magnet:") == 0) {
+			LoadTorrentFromMagnet(arg);
+		}
+	}
+}
+
 void TorrentorApp::Pulse()
 {
 	if( fMainWindow != NULL )
@@ -426,16 +436,18 @@ void TorrentorApp::OpenTorrentResult(BMessage* message)
 
 void TorrentorApp::LoadTorrentFromMagnet(BMessage* message)
 {
-	BString MagnetUrl;
-	
-	
-	if( message->FindString("URL", &MagnetUrl) != B_OK )
+	BString magnetUrl;
+	if( message->FindString("URL", &magnetUrl) != B_OK )
 		return;
-
 	
+	LoadTorrentFromMagnet(magnetUrl);
+}
+
+void TorrentorApp::LoadTorrentFromMagnet(BString magnetUrl)
+{
 	TorrentObject* torrentObject = new TorrentObject();
 		
-	if( !torrentObject->LoadFromMagnet(Session(), MagnetUrl) )
+	if( !torrentObject->LoadFromMagnet(Session(), magnetUrl) )
 	{
 		delete torrentObject;
 		return;

--- a/source/torrentor/Application.h
+++ b/source/torrentor/Application.h
@@ -56,6 +56,7 @@ public:
 	//
 	void MessageReceived(BMessage* message);
 	void RefsReceived(BMessage* message);
+	void ArgvReceived(int32 argc, char** argv);
 	void Pulse();
 	void ReadyToRun();
 	
@@ -64,6 +65,7 @@ protected:
 	void LoadTorrentList();
 	void LoadTorrentFromFiles(const BStringList& TorrentPathList);
 	void LoadTorrentFromMagnet(BMessage* message);
+	void LoadTorrentFromMagnet(BString magnetUrl);
 	void OpenTorrentResult(BMessage* message);
 	void OpenMagnetLinkWindow();
 	void CheckForUpdates();

--- a/source/torrentor/Torrentor.rdef
+++ b/source/torrentor/Torrentor.rdef
@@ -45,5 +45,6 @@ resource app_version {
 
 resource file_types message 
 {
-	"types" = "application/x-bittorrent"
+	"types" = "application/x-bittorrent",
+	"types" = "application/x-vnd.Be.URL.magnet"
 };


### PR DESCRIPTION
Hi, I have another small one. :)

This patch makes Torrentor handle magnet: links directly -- theoretically. WebPositive, however, doesn't recognize them as links and tries to open HTTP://magnet:something. It's a bug in Web+.

You can test it though by copying the link and running in a terminal:
~> open "magnet:..."

I don't know where one can file bugs for Web+ but if they fix that, there is a pretty nice torrent "workflow" on Haiku, thanks to you! Thanks for writing Torrentor, and thanks for releasing the source code!

Hopefully I can contribute a few other patches in the future (if you're interested).
